### PR TITLE
Testing with Catch2 framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 *.out
 *.app
 powdersim
+powdersim_tests
 
 # CMake
 CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,46 @@
 cmake_minimum_required(VERSION 3.12)
 set(CMAKE_CXX_STANDARD 20)
 
-set(EXECUTABLE_NAME "powdersim")
 set(PROJECT_NAME "Powder Simulator")
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # generates clangd file
-
 project(${PROJECT_NAME} VERSION 0.1)
 
-# recursively finds .cpp files in src/ and adds them to the target
-file(GLOB_RECURSE SOURCES "src/*.cpp")
+# CMake config
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # generates clangd file
+
+##################
+# Main Executable
+##################
+
+set(PROJECT_EXECUTABLE "powdersim")
+
+# recursively finds .cpp files in src/ and adds them to the main executable
+file(GLOB_RECURSE PROJECT_SOURCES "src/*.cpp")
+
 # ;main.cpp adds driver file to target
-add_executable(${EXECUTABLE_NAME} "${SOURCES};main.cpp")
+add_executable(${PROJECT_EXECUTABLE} "${PROJECT_SOURCES};main.cpp")
 
 # looks in src/ for include directories
-target_include_directories(${EXECUTABLE_NAME} PRIVATE "src")
+target_include_directories(${PROJECT_EXECUTABLE} PRIVATE "src")
 
 # links SFML
 find_package(SFML REQUIRED COMPONENTS graphics system window)
-target_link_libraries(${EXECUTABLE_NAME} sfml-graphics sfml-system sfml-window)
+target_link_libraries(${PROJECT_EXECUTABLE} sfml-graphics sfml-system sfml-window)
+
+##################
+# Test Executable
+##################
+
+set(TEST_EXECUTABLE "powdersim_tests")
+
+# recursively finds .cpp files in tests/ and adds them to the testing executable
+file(GLOB_RECURSE TEST_SOURCES "tests/*.cpp")
+
+# ;main.cpp adds driver file to target
+add_executable(${TEST_EXECUTABLE} ${TEST_SOURCES})
+
+# looks in tests/ for include directories
+target_include_directories(${TEST_EXECUTABLE} PRIVATE "tests")
+
+# links Catch2
+find_package(Catch2 3 REQUIRED)
+target_link_libraries(${TEST_EXECUTABLE} PRIVATE Catch2::Catch2WithMain)

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -1,0 +1,23 @@
+#include <catch2/catch_test_macros.hpp>
+
+uint factorial(uint value)
+{
+    if (value <= 1)
+        return 1;
+
+    return value * factorial(value - 1);
+}
+
+TEST_CASE("Test Success")
+{
+    REQUIRE(factorial(0) == 1);
+    REQUIRE(factorial(1) == 1);
+    REQUIRE(factorial(2) == 2);
+    REQUIRE(factorial(3) == 6);
+    REQUIRE(factorial(4) == 24);
+}
+
+TEST_CASE("Test Fail")
+{
+    REQUIRE(factorial(5) == 100);
+}


### PR DESCRIPTION
To run the tests, simply run `cmake .` and then `make` like usual. It now generates a `powdersim_tests` executable that can be run separately from the project executable.

After running `./powdersim_tests`, you should see two test cases, one success and one failure. You should also see six asserts, with five successes and one failure. The failed case is intentional, it should never succeed.